### PR TITLE
Improvements to single person selection and few other minor fixes

### DIFF
--- a/ZLPeoplePickerViewController/Internal/ZLBaseTableViewController.m
+++ b/ZLPeoplePickerViewController/Internal/ZLBaseTableViewController.m
@@ -156,6 +156,8 @@
         cell.accessoryType = UITableViewCellAccessoryNone;
         // cell.selectionStyle = UITableViewCellSelectionStyleDefault;
     }
+    
+    [cell setSelectionStyle:UITableViewCellSelectionStyleNone];
 
     APContact *contact = [self contactForRowAtIndexPath:indexPath];
     [self configureCell:cell forContact:contact];

--- a/ZLPeoplePickerViewController/Internal/ZLTypes.h
+++ b/ZLPeoplePickerViewController/Internal/ZLTypes.h
@@ -11,6 +11,7 @@
 
 typedef NS_ENUM(NSUInteger, ZLNumSelection) {
     ZLNumSelectionNone = 0,
+    ZLNumSelectionOne = 1,
     ZLNumSelectionMax = NSUIntegerMax
 };
 

--- a/ZLPeoplePickerViewController/ZLPeoplePickerViewController.h
+++ b/ZLPeoplePickerViewController/ZLPeoplePickerViewController.h
@@ -31,7 +31,7 @@
  *  @param people     An array of recordIds
  */
 - (void)peoplePickerViewController:(nonnull ZLPeoplePickerViewController *)peoplePicker
-       didReturnWithSelectedPeople:(nonnull NSArray *)people;
+       didReturnWithSelectedPeople:(nullable NSArray *)people;
 
 /**
  *  Tells the delegate that the people picker's ABNewPersonViewController did complete

--- a/ZLPeoplePickerViewController/ZLPeoplePickerViewController.h
+++ b/ZLPeoplePickerViewController/ZLPeoplePickerViewController.h
@@ -20,8 +20,8 @@
  *  @param peoplePicker The people picker object providing this information.
  *  @param recordId     The person's recordId in ABAddressBook
  */
-- (void)peoplePickerViewController:(ZLPeoplePickerViewController *)peoplePicker
-                   didSelectPerson:(NSNumber *)recordId;
+- (void)peoplePickerViewController:(nonnull ZLPeoplePickerViewController *)peoplePicker
+                   didSelectPerson:(nonnull NSNumber *)recordId;
 
 /**
  *  Tells the delegate that the people picker has returned and, if the type is
@@ -30,8 +30,8 @@
  *  @param peoplePicker The people picker object providing this information.
  *  @param people     An array of recordIds
  */
-- (void)peoplePickerViewController:(ZLPeoplePickerViewController *)peoplePicker
-       didReturnWithSelectedPeople:(NSArray *)people;
+- (void)peoplePickerViewController:(nonnull ZLPeoplePickerViewController *)peoplePicker
+       didReturnWithSelectedPeople:(nonnull NSArray *)people;
 
 /**
  *  Tells the delegate that the people picker's ABNewPersonViewController did complete
@@ -45,7 +45,7 @@
 @end
 
 @interface ZLPeoplePickerViewController : ZLBaseTableViewController
-@property (weak, nonatomic) id<ZLPeoplePickerViewControllerDelegate> delegate;
+@property (weak, nonatomic, nullable) id<ZLPeoplePickerViewControllerDelegate> delegate;
 @property (nonatomic) ZLNumSelection numberOfSelectedPeople;
 
 + (void)initializeAddressBook;

--- a/ZLPeoplePickerViewController/ZLPeoplePickerViewController.m
+++ b/ZLPeoplePickerViewController/ZLPeoplePickerViewController.m
@@ -387,6 +387,9 @@
             [[self presentingViewController] dismissViewControllerAnimated:YES completion:nil];
             [self invokeReturnDelegate];
         }
+        else {
+            [self dismissViewControllerAnimated:YES completion:NULL];
+        }
     }
     else {
         [self dismissViewControllerAnimated:YES completion:NULL];
@@ -400,7 +403,7 @@
             respondsToSelector:@selector(peoplePickerViewController:
                                         didReturnWithSelectedPeople:)]) {
         [self.delegate peoplePickerViewController:self
-                      didReturnWithSelectedPeople:[self.selectedPeople copy]];
+                      didReturnWithSelectedPeople:[self.selectedPeople allObjects]];
     }
 }
 

--- a/ZLPeoplePickerViewController/ZLPeoplePickerViewController.m
+++ b/ZLPeoplePickerViewController/ZLPeoplePickerViewController.m
@@ -16,8 +16,7 @@
 #import "APContact+Sorting.h"
 
 @interface ZLPeoplePickerViewController () <
-    ABPeoplePickerNavigationControllerDelegate, ABPersonViewControllerDelegate,
-    ABNewPersonViewControllerDelegate, ABUnknownPersonViewControllerDelegate,
+    ABPeoplePickerNavigationControllerDelegate, ABNewPersonViewControllerDelegate,
     UISearchBarDelegate, UISearchControllerDelegate, UISearchResultsUpdating>
 @property (strong, nonatomic) UIRefreshControl *refreshControl;
 @property (nonatomic, strong) UISearchController *searchController;
@@ -31,6 +30,7 @@
 @end
 
 @implementation ZLPeoplePickerViewController
+@dynamic refreshControl;    // getter and setter methods implemened by the superclass
 
 - (instancetype)init {
     self = [super init];
@@ -142,7 +142,7 @@
         initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                              target:peoplePicker
                              action:@selector(doneButtonAction:)];
-    peoplePicker.delegate = parentViewController;
+    peoplePicker.delegate = (id<ZLPeoplePickerViewControllerDelegate>)parentViewController;
     [parentViewController presentViewController:navController
                                        animated:YES
                                      completion:nil];
@@ -239,6 +239,18 @@
     } else {
         if (self.selectedPeople.count < self.numberOfSelectedPeople) {
             [self.selectedPeople addObject:contact.recordID];
+        } else {
+            if(self.numberOfSelectedPeople == 1) {
+                if (![tableView isEqual:self.tableView]) {
+                    ZLResultsTableViewController *tableController =
+                        (ZLResultsTableViewController *)
+                        self.searchController.searchResultsController;
+                    tableController.selectedPeople = nil;
+                    [tableController.selectedPeople addObject:contact.recordID];
+                }
+                self.selectedPeople = nil;
+                [self.selectedPeople addObject:contact.recordID];
+            }
         }
     }
 
@@ -361,12 +373,24 @@
 - (void)newPersonViewController:
             (ABNewPersonViewController *)newPersonViewController
        didCompleteWithNewPerson:(ABRecordRef)person {
-    [self dismissViewControllerAnimated:YES completion:NULL];
+
     if (self.delegate &&
         [self.delegate
          respondsToSelector:@selector(newPersonViewControllerDidCompleteWithNewPerson:)]) {
             [self.delegate newPersonViewControllerDidCompleteWithNewPerson:person];
          }
+    
+    if(self.numberOfSelectedPeople == 1) {
+        if(person) {
+            self.selectedPeople = nil;
+            [self.selectedPeople addObject:[NSNumber numberWithInt:ABRecordGetRecordID(person)]];
+            [[self presentingViewController] dismissViewControllerAnimated:YES completion:nil];
+            [self invokeReturnDelegate];
+        }
+    }
+    else {
+        [self dismissViewControllerAnimated:YES completion:NULL];
+    }
 }
 
 #pragma mark - ()


### PR DESCRIPTION
I know you gave me push access, but I wanted to run this by you first, because it changes the basic functionality of the single user selection.  If you approve, I'll push them or you can merge them.  Thanks!
1. Improved usability when `numberOfSelectedPeople == 1` 
   - Changes the `selectedPeople` set as you pick a new person, so you don't have to un-select the previous person to select a new person
   - When adding a new person by pressing Done in the ABNewPersonViewController and in modal view mode, dismiss back to the presenting view controller and didReturn delegate called with the new person
2. Set UITableViewCell selection style to none => No more flicker when you select a user
3. Fixed a few compiler warnings and added some nullability specifiers to ZLPeopePickerViewController.[mh]
